### PR TITLE
Add option to generate non-square image box ratios

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -450,7 +450,7 @@ class App extends React.Component {
     });
   }
 
-  // Return to image selection
+  // Allow rectangular image boxes or not.
   handleChangeSquareOnly(isSquareOnly) {
     this.setState(state => {
       return {

--- a/src/App.js
+++ b/src/App.js
@@ -197,6 +197,9 @@ function ImgControls(props) {
           </div>
           <button className='finish' onClick={props.onFinish}>Finish</button>
         </div>
+        <div className='number squareOnly'>
+          <label><input type='checkbox' checked={props.isSquareOnly} onChange={props.onChangeSquareOnly} /> Square only</label>
+        </div>
       </div>
     );
   }
@@ -285,6 +288,7 @@ class App extends React.Component {
     super(props);
     this.year = new Date().getFullYear();
     this.defaultState = {
+      isSquareOnly: true,
       imgSelected: false,
       imgLoaded: false,
       imgCropped: false,
@@ -358,7 +362,7 @@ class App extends React.Component {
   // Set height of crop boxes
   handleCropHeight(input) {
     const newHeight = Number(input.value);
-    const newWidth = calculateMaxHeight(newHeight, this.state.cropWidth);
+    const newWidth = this.state.isSquareOnly ? newHeight : calculateMaxHeight(newHeight, this.state.cropWidth);
     // Set new max x pos
     const newMaxX = this.state.imgWidth - (this.state.boxCount * newWidth);
     // Set new max box count
@@ -448,6 +452,13 @@ class App extends React.Component {
   }
 
   // Return to image selection
+  handleChangeSquareOnly(isSquareOnly) {
+    this.setState({
+      isSquareOnly
+    });
+  }
+
+  // Return to image selection
   handleCancel() {
     this.setState(this.defaultState);
   }
@@ -502,6 +513,7 @@ class App extends React.Component {
           </div>
           <ImgControls
             show={this.state.imgLoaded && !this.state.imgCropped}
+            isSquareOnly={this.state.isSquareOnly}
             boxCount={this.state.boxCount}
             boxCountMax={this.state.boxCountMax}
             minHeight={this.state.imgHeight}
@@ -515,6 +527,7 @@ class App extends React.Component {
             onYPos={(e) => this.handleStartY(e.target)}
             onBoxMinus={() => this.handleBoxMinus()}
             onBoxPlus={() => this.handleBoxPlus()}
+            onChangeSquareOnly={(e) => this.handleChangeSquareOnly(e.target.checked)}
             onCancel={() => this.handleCancel()}
             onFinish={() => this.handleFinish()}
           />

--- a/src/App.js
+++ b/src/App.js
@@ -360,9 +360,9 @@ class App extends React.Component {
     const newHeight = Number(input.value);
     const newWidth = calculateMaxHeight(newHeight, this.state.cropWidth);
     // Set new max x pos
-    const newMaxX = this.state.imgWidth - (this.state.boxCount * newHeight);
+    const newMaxX = this.state.imgWidth - (this.state.boxCount * newWidth);
     // Set new max box count
-    const newMaxBoxCount = Math.floor(this.state.imgWidth / newHeight);
+    const newMaxBoxCount = Math.floor(this.state.imgWidth / newWidth);
     // Make sure crop area isn't growing off right edge
     if (this.state.startX > newMaxX) {
       this.setState({

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import React from 'react';
 import logo from './icons/logo.svg';
 import './App.scss';
 
+import {calculateMaxHeight} from './InstagramSizes';
+
 // Document header
 function Header(props) {
   if (props.show) {
@@ -356,7 +358,7 @@ class App extends React.Component {
   // Set height of crop boxes
   handleCropHeight(input) {
     const newHeight = Number(input.value);
-    const newWidth = newHeight;
+    const newWidth = calculateMaxHeight(newHeight, this.state.cropWidth);
     // Set new max x pos
     const newMaxX = this.state.imgWidth - (this.state.boxCount * newHeight);
     // Set new max box count
@@ -401,6 +403,9 @@ class App extends React.Component {
     const panoRatio = this.state.imgWidth / this.state.imgHeight;
     const cropRatio = (this.state.boxCount * this.state.cropWidth) / this.state.cropHeight;
     let newMaxHeight = panoRatio * this.state.imgHeight / cropRatio;
+    
+
+    
     // Make sure new height isn't greater than image height
     if (newMaxHeight > this.state.imgHeight) {
       newMaxHeight = this.state.imgHeight;

--- a/src/App.scss
+++ b/src/App.scss
@@ -248,6 +248,9 @@ header {
       background-image: url($imgPlus);
     }
   }
+  .squareOnly {
+    margin-top: 16px;
+  }
   .confirm {
     padding: 0 8px;
     display: flex;

--- a/src/InstagramSizes.js
+++ b/src/InstagramSizes.js
@@ -1,0 +1,9 @@
+export const InstagramSizes = {
+    horizontalMax: 1.91 / 1,
+    verticalMax: 4 / 5,
+    maxDimensionPx: 1080
+}
+
+export function calculateMaxHeight(width, height) {
+    return width * InstagramSizes.verticalMax;
+};


### PR DESCRIPTION
Hey Max, great app! Thanks for making it. I've always wanted this non-square feature but I've never seen any other panorama app do it correctly, so I'm glad I found your code and was able to modify it easily enough.

The user can click a checkbox which will pick the best image box ratio that still fits on Instagram. This will allow them to capture more of the panorama if there is too much remainder when splitting them up into squares, without having to crop vertically.

Let me know if you'd like me to squash all these commits into one before merging.